### PR TITLE
Adding a delay to the config store watch.

### DIFF
--- a/server/boot/05-watch-configstore.js
+++ b/server/boot/05-watch-configstore.js
@@ -8,7 +8,13 @@ const {ensureProjectFileExists, ensureFunctionModelSynchronization} = require('.
 
 const DETACHED = '0000000000000000000000000000000000000000';
 
-module.exports = function (app, cb) {
+module.exports = function (app) {
+  setTimeout(() => {
+    watchConfigStore();
+  }, process.env.WATCH_DELAY || 30000);
+};
+
+function watchConfigStore (app) {
   const status = app.models.Project.workspaceStatus;
   const branch = config.branch;
 
@@ -76,6 +82,4 @@ module.exports = function (app, cb) {
       connected = false;
     }
   });
-
-  cb();
 };


### PR DESCRIPTION
When a workspace container starts, the config store watch to the EventSource URL happens immediately.

However, at least in the Triton environment, it appears that networking hasn't been set up properly yet.  The socket hangs and never recovers.

This delay is a hopeful attempt to ensure all networking components are set up in the container and are ready to go.  Because static delays are fragile depending on the environment, there's an environment variable that can be defined to set the delay time.

We should do a deeper dive to get all the details on why this happens.

