### PR TITLE
Functions repo watch connect LunchBadger/serverless-api#6, connect LunchBadger/lunchbadger-ui#778

### DIFF
--- a/server/boot/05-watch-configstore.js
+++ b/server/boot/05-watch-configstore.js
@@ -41,6 +41,9 @@ module.exports = function (app, cb) {
           await app.models.WorkspaceStatus.proc.reinstallDeps();
         } else {
           debug('resetting functions state');
+          // TODO: this is not needed, it is just to test refresh before UI hot reload implementation
+          status.instance = uuid();
+          // this is the field UI should rely on for function hot reload
           status.sls_api = uuid();
         }
       } catch (err) {


### PR DESCRIPTION
This is a very limited version. It is more of a protection from the baking screen on git push to functions repo

LBWS cannot determine if push to functions repo was internal or external. 
SLS-API must talk to LBWS with that info. 

NATS would be the best way to communicate. Alternatively it can be a webhook approach, SLS-API just does POST to some LBWS endpoint 