### PR TITLE
removing unused revision field from API

### DIFF
--- a/server/boot/03-init-workspace.js
+++ b/server/boot/03-init-workspace.js
@@ -6,12 +6,11 @@ module.exports = async (app, cb) => {
   try {
     let rev = await ensureWorkspace(app);
     const id = uuidv1();
-    debug('Starting App with id ', id);
+    debug('Starting App with id ', id, 'local rev', rev);
     let status = await app.models.WorkspaceStatus.create({
       running: false,
       output: '',
-      instance: id,
-      revision: rev
+      instance: id
     });
     app.models.Project.workspaceStatus = status;
     cb();


### PR DESCRIPTION
As discussed with @kolbinski this field is not used by server or UI so no point to keep it